### PR TITLE
chore: Update to Axe.Windows 2.0.0

### DIFF
--- a/src/AccessibilityInsights.SharedUx/SharedUx.csproj
+++ b/src/AccessibilityInsights.SharedUx/SharedUx.csproj
@@ -10,7 +10,7 @@
   <Import Project="..\..\build\NetFrameworkRelease.targets" />
 
   <ItemGroup>
-    <PackageReference Include="Axe.Windows" Version="1.1.7" />
+    <PackageReference Include="Axe.Windows" Version="2.0.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.39" />
     <Reference Include="Interop.UIAutomationClient, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/UITests/UILibrary/AIWinDriver.cs
+++ b/src/UITests/UILibrary/AIWinDriver.cs
@@ -5,6 +5,7 @@ using Axe.Windows.Automation;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenQA.Selenium.Appium.Windows;
 using System.IO;
+using System.Linq;
 using static System.FormattableString;
 
 namespace UITests.UILibrary
@@ -48,7 +49,7 @@ namespace UITests.UILibrary
 
             var scanner = ScannerFactory.CreateScanner(config);
 
-            var result = scanner.Scan();
+            var result = scanner.Scan(null).WindowScanOutputs.First();
             if (result.ErrorCount > 0)
             {
                 var newPath = Path.Combine(outputPath, Invariant($"{fileName}.a11ytest"));

--- a/src/UITests/UITests.csproj
+++ b/src/UITests/UITests.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Appium.WebDriver" Version="4.3.2" />
-    <PackageReference Include="Axe.Windows" Version="1.1.7" />
+    <PackageReference Include="Axe.Windows" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />


### PR DESCRIPTION
This is a preview of the changes needed to consume the new IScanner interface in our UITests
